### PR TITLE
Fix username event emission

### DIFF
--- a/frontend/src/components/dashboard/panels/settings/ProfileSettings.tsx
+++ b/frontend/src/components/dashboard/panels/settings/ProfileSettings.tsx
@@ -44,7 +44,7 @@ export default function ProfileSettings() {
         try {
             await changeUsername(clean);
             const msg = `✅ Username changed to ${clean}`;
-            emit("auth_success", msg);
+            emit("username", msg);
             await new Promise(res => setTimeout(res, 1000)); // <-- Try adding this
             await refreshUser();
         } catch (err) {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- broadcast username update events with the `username` type so they display in MycoCore
- add vitest config to run tests with jsdom and alias resolution

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_687719923304832ca7dc6dbec1b0186e